### PR TITLE
Better format for algorithms and improve structure.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -59,6 +59,18 @@
       table.grammar td:nth-child(2) {
         text-align: right;
       }
+      .algorithm ol {
+        counter-reset: numsection;
+        list-style-type: none;
+      }
+      .algorithm ol>li {
+        margin: 0.5em 0;
+      }
+      .algorithm ol>li:before {
+        font-weight: bold;
+        counter-increment: numsection;
+        content: counters(numsection, ".") ") ";
+      }
     </style>
     <script>
       function _esc(s) {
@@ -107,7 +119,7 @@
       <p>Below, we elaborate on the main characteristics of <abbr title="Notation3">N3</abbr>:</p>
       <ul>
         <li>
-          <strong><abbr title="Notation3">N3</abbr> is a superset of RDF and <abbr title="Terse RDF Triple Language">Turtle</abbr>.</strong> One can write any valid [[[Turtle]]] graph, and it will be valid in <abbr title="Notation3">N3</abbr> as well. Importantly, this means that all of Turtle's syntactic sugar is available in <abbr title="Notation3">N3</abbr> &mdash; including <a href="#polists">predicate and object lists</a>, unlabeled blank nodes, and <a>collections</a>. Moreover, <strong><a>collections</a> are first-class citizens</strong> in <abbr title="Notation3">N3</abbr>, with an associated set of <a>builtins</a> for accessing and manipulating them.
+          <strong><abbr title="Notation3">N3</abbr> is a superset of RDF and <abbr title="Terse RDF Triple Language">Turtle</abbr>.</strong> One can write any valid [[[Turtle]]] graph, and it will be valid in <abbr title="Notation3">N3</abbr> as well. Importantly, this means that all of Turtle's syntactic sugar is available in <abbr title="Notation3">N3</abbr> &mdash; including <a href="#polists">predicate and object lists</a>, unlabeled blank nodes, and <a>collections</a>. Moreover, <strong><a>collections</a> are first-class citizens</strong> in <abbr title="Notation3">N3</abbr>, with an associated set of <a>built-ins</a> for accessing and manipulating them.
         </li>
         <li>
           <strong><abbr title="Notation3">N3</abbr> adds an If-Then style of decision making in the form of logical implications and variables.</strong> Logical implications allow making If-Then style inferences via modus ponens (where implementations may apply either backward- or forward-chaining). Variables in such rules may be quantified either universally or existentially; in the latter case, they are comparable to blank nodes. 
@@ -116,7 +128,7 @@
           <strong><abbr title="Notation3">N3</abbr> supports quoting and describing graphs of statements (e.g., recording provenance).</strong> In an open web environment, as an unbounded sea of (semi-)connected sources, one should be made aware of, and given the ability to disseminate, the provenance of information, among other things. A <a>quoted graph</a> includes a conjunction of quoted statements. It allows expression of where the particular statements (e.g., message, document) came from, at what time they were stated and by whom, and, in general, any other description of them.
         </li>
         <li>
-          <strong><abbr title="Notation3">N3</abbr> includes a core set of <a>builtins</a> for accessing remote online information.</strong> In an open web environment, any online source may have information that supports decision making. The <code>log:semantics</code> <a>built-in</a> allows pulling in (parsed) logical expressions from remote online locations; the <code>log:conclusion</code> <a>built-in</a> allows calculating the deductive closure of any logical expression, whether local or remote. Subsequently, down-stream operations may, for instance, check whether other expressions are included, or not included, within these logical expressions.
+          <strong><abbr title="Notation3">N3</abbr> includes a core set of <a>built-ins</a> for accessing remote online information.</strong> In an open web environment, any online source may have information that supports decision making. The <code>log:semantics</code> <a>built-in</a> allows pulling in (parsed) logical expressions from remote online locations; the <code>log:conclusion</code> <a>built-in</a> allows calculating the deductive closure of any logical expression, whether local or remote. Subsequently, down-stream operations may, for instance, check whether other expressions are included, or not included, within these logical expressions.
         </li>
         <li>
           <strong><abbr title="Notation3">N3</abbr> supports a scoped version of negation-as-failure.</strong> In an open web environment, it is often useful to check whether or not online information supports, or allows derivation of, a given set of facts. However, it will not be possible nor useful to check whether the whole Semantic Web <em>does not</em> support a given set of facts at some time &mdash; any online source, unknown to the reasoner at the time, or added after the question was asked, may hold a positive answer. Instead, a useful question in this setting is whether a <em>specific</em> piece of information, at a given point in time, does or does not support, or does or does not allow the derivation of, a set of facts. When tightly scoped to a specific information source, and at a specific time, this kind of negation-as-failure will not be influenced by other, unknown online sources. This is referred to as <em>scoped negation as failure,</em> and is supported by <abbr title="Notation3">N3</abbr>'s <code>log:notIncludes</code> <a>built-in</a>.
@@ -860,12 +872,12 @@ To illustrate that consider the following example:
 	</section>
 	
   <section id='builtins'>
-	<h3>N3 builtins</h3>
-	<p><abbr title="Notation3">N3</abbr> defines a core set of <dfn>builtins</dfn>: these are predicates 
+	<h3>N3 built-ins</h3>
+	<p><abbr title="Notation3">N3</abbr> defines a core set of <dfn data-lt="builtin">built-ins</dfn>: these are predicates 
 	with pre-defined semantics for querying, manipulating and reasoning over <a>N3 documents</a>. 
-	Builtins are grouped into distinct vocabularies depending on the <a>N3 triple elements</a> they operate on (e.g., string, list), 
+	built-ins are grouped into distinct vocabularies depending on the <a>N3 triple elements</a> they operate on (e.g., string, list), 
 	or their particular topic (e.g., time, cryptography, log).
-	Builtins are denoted by a controlled IRI defined in one of the core built-in namespaces:</p>
+	built-ins are denoted by a controlled IRI defined in one of the core built-in namespaces:</p>
 		<ul>
 		  <li><a href="../ns/crypto.html">Crypto</a> –
 			<a href="http://www.w3.org/2000/10/swap/crypto#">http://www.w3.org/2000/10/swap/crypto#</a>,</li>
@@ -916,6 +928,7 @@ To illustrate that consider the following example:
 		<p>The expected datatypes of arguments, i.e., domain datatypes, are defined per N3 built-in.</p>
 		<p>If the <a>value datatype</a> and <a>domain datatype</a> do not match, and no casting or substitution is possible, the built-in statement will be considered false. (This is in line with the concept of the built-in <a>theory box</a>: a BPG search using the built-in statement will not match any statement in the theory box when literal datatypes do not match.</p>
 		
+    <section>
 		<h5>Numeric datatype promotion and substitution</h5>
 		<p>If the numeric <a>value datatype</a> does not match the <a>domain datatype</a>, it may be possible to promote or substitute the numeric value datatype:</p>
 		
@@ -929,28 +942,35 @@ To illustrate that consider the following example:
 		
 		<p><b>Numeric type substitution</b>: If <i>all values</i> have the same numeric datatype, and this datatype <a href="https://www.w3.org/TR/xmlschema-2/#dt-derived">is derived from</a> the domain datatype (e.g., `xs:integer` is derived from `xs:decimal`), then the values can be used without any casting. For example, if two `xs:integer` values are used for input where `xs:decimal` domains are expected, then the values retain their datatype as `xs:integer`. The substituted numeric datatype (in this case, `xs:integer`) will also apply to the built-in's output, if any.</p>
 
-		<p><b>Builtins operating on any numeric type</b>: some N3 builtins (e.g., `math:sum`) operate on values of any numeric type (i.e., `xs:numeric`, the union of `xs:double`, `xs:float`, and `xs:decimal`). I.e., their concrete input values may present any combination of numeric types. In that case, the built-in can only be applied if all value datatypes can be promoted into <i>a common numeric datatype</i> in the ordered list `(xs:integer, xs:decimal, xs:float, xs:double)`. If so, at that point, we rely on numeric type substitution. For instance:
+		<p><b>built-ins operating on any numeric type</b>: some N3 built-ins (e.g., `math:sum`) operate on values of any numeric type (i.e., `xs:numeric`, the union of `xs:double`, `xs:float`, and `xs:decimal`). I.e., their concrete input values may present any combination of numeric types. In that case, the built-in can only be applied if all value datatypes can be promoted into <i>a common numeric datatype</i> in the ordered list `(xs:integer, xs:decimal, xs:float, xs:double)`. If so, at that point, we rely on numeric type substitution. For instance:
 			<ul>
 				<li>For a built-in with `xs:numeric` domain datatypes, given two value datatypes `xs:integer` and `xs:decimal`, the `xs:integer` value will be promoted to `xs:decimal` as the common numeric datatype. At that point, the two `xs:decimal` datatypes can be substituted for `xs:numeric` (numeric type substitution). If the built-in has an output, then the calculated value for this output will also have datatype `xs:decimal`.</li>
 				<li>For a built-in with `xs:numeric` domain datatypes, given two values with datatype `xs:integer`, the `xs:integer` datatype will simply be substituted for `xs:numeric`. If the built-in has an output, then the calculated value for the output will also have datatype `xs:integer`.</li>
 			</ul>
 		</p>
+    </section>
 		
+    <section>
 		<h5>Other kinds of datatype casting</h5>
 
 		<p>If the non-numeric <a>value datatype</a> does not match the <a>domain datatype</a>, it may be possible to cast the value datatype to the domain datatype:</p>
+    </section>
 		
+    <section>
 		<h6>String</h6>
 		<p>A literal will be considered a "string" when it has an `xs:string` datatype, a `rdf:langString` datatype due to the presence of a language tag, or when it lacks a datatype.</p>
 		
 		<p><b>Casting from string</b>: if an input value has an `xs:string` datatype that does not match the domain, it may be possible to cast the string to the domain datatype, as <a href="https://www.w3.org/TR/xpath-functions/#casting-from-strings">defined in XPath</a>. The resulting value representation must be a valid lexical form for the domain datatype.</p>
 		<p><b>Casting to string</b>: if an input value is an IRI, or any kind of literal (incl. type `xs:anyUri` or its derivations), and the domain is `xs:string`, then the value will be cast to a string as <a href="https://www.w3.org/TR/xpath-functions/#casting-to-string">defined in XPath</a> along with additional rules <a href="https://www.w3.org/TR/sparql11-query/#FunctionMapping">defined for SPARQL 1.1</a>.</p>
+    </section>
 		
+    <section>
 		<h6>Other datatypes</h6>
 		
 		<p>Other types of datatype casting may take place as <a href="https://www.w3.org/TR/xpath-functions/#casting">defined in XPath</a>. 
 
 		<p class="ednote">There is a useful chart for casting primitive types to primitive types in <a href="https://www.w3.org/TR/xpath-functions/#casting-from-primitive-to-primitive">XPath</a>, a subset of which is defined for <a href="https://www.w3.org/TR/sparql11-query/#FunctionMapping">SPARQL</a>.</p>
+    </section>
 	</section>
 	
 	<section id="builtin_operations">
@@ -966,9 +986,10 @@ To illustrate that consider the following example:
 		<p>If a built-in statement has both inputs and outputs, one or more values can be calculated for the outputs so as to ensure its truthfulness. For instance, given `(2 1) math:sum ?s`, the N3 system will calculate value `3` for output `?s`.</p>
 		<p>These operations may include casting or substituting values to different domains, as discussed in <a href="#builtin_arg_domains">Argument domains</a>.</p>
 			
+    <section>
 		<h5>built-in theory box</h5>
 		<p>Before elaborating on these operations, we point out that a built-in statement can be more conventiently seen as a <i>constrained</i> basic graph pattern (BPG) search on the N3 built-in’s <dfn>theory box</dfn>, defined to include all truthful built-in statements for the N3 built-in.</p>
-		<p>The two operations mentioned, i.e., <a>checking</a> and <a>calculating</a>, can be defined in terms of this constrained BGP search. This leaves the particular theory box to be defined per N3 built-in. N3 builtins are currently not defined in this manner, though.</p>
+		<p>The two operations mentioned, i.e., <a>checking</a> and <a>calculating</a>, can be defined in terms of this constrained BGP search. This leaves the particular theory box to be defined per N3 built-in. N3 built-ins are currently not defined in this manner, though.</p>
 		
 		<p>For eample, for the `math:sum` built-in, simply put, the theory box includes all built-in statements `($a_1 .. $a_n) math:sum $a_sum`, where all arguments have datatype `xs:numeric`, and where the sum of `$a_1 .. $a_n` equals `$a_sum`. Regarding operation (1), the built-in statement `(2 1) math:sum 3` is found in the built-in's theory box, meaning the statement is true. Regarding operation (2), the built-in statement `(2 1) math:sum ?sum`, matches the built-in statement `(2 1) math:sum 3` in the built-in's theory box. Hence, `3` is calculated as value for output `?sum` that ensures the truthfulness of the built-in statement.</p>
 		
@@ -978,7 +999,10 @@ To illustrate that consider the following example:
 		
 		<p class="ednote">It may be counter-intuitive that a <a>built-in statement</a>, where the variables needed to calculate an <a>output</a> are not all concrete <a>inputs</a> (e.g., `(?a 1) math:sum ?s`), will not cause an N3 rule to fail, since the built-in statement will be considered true.<br /><br />
 		This may have unintended consequences: instead of the rule failing, rule heads will be instantiated that include unbound universal variables (e.g., `?sum`). As a result, N3 systems are expected to generate witnesses in such cases (link..).</p>
+      
+    </section>
 		
+    <section class="algorithm">
 		<h5>Built-in algorithm</h5>
 		<p>In line with the concept of a built-in theory box, we can define an algorithm to perform <a>checking</a> and <a>calculating</a> operations.</p>
 		<p>Depending on the definition of the built-in, with supported <a>output arguments</a> and <a>domain datatypes</a>, and the built-in <a>inputs</a> and <a>outputs</a> found in <a>built-in </a>statement:</p>		
@@ -1015,13 +1039,15 @@ To illustrate that consider the following example:
 					</li>
 				</ol>
 			</li>
-		</ol>		
+		</ol>
+    </section>
 	</section>
 	
 	<section id="builtins_use_cases">
 		<h4>Built-in use cases</h4>
-		<p>Here we look at how the various builtins can be combined and utilized in example use cases.</p>
+		<p>Here we look at how the various built-ins can be combined and utilized in example use cases.</p>
 		
+    <section>
 		<h5>Task workflows</h5>
 		
 		<p>Using `log:forAllIn`, one can check whether certain elements adhere to a given condition, and, if so, infer a conclusion. 
@@ -1059,7 +1085,8 @@ To illustrate that consider the following example:
 			} => { ?workflow :completed ?completed } .
 		  -->
 		  <p>The <a>built-in statement</a> collects all `?task` bindings, i.e., for which the `{ ?workflow :includes ?task . ?task a :Completed }` statements are true, into the `?completed` list for the current context `_:x`, and infers the conclusion.</p>
-		</pre>		
+		</pre>
+    </section>
 	</section>	
   </section>
   
@@ -1511,7 +1538,7 @@ To illustrate that consider the following example:
           -->
         </pre>
         <p><abbr title="Notation3">N3</abbr> is not directly compatible with TriG as it does not support this graph statement notation. Nevertheless, since <abbr title="Notation3">N3</abbr> supports <a>quoted graphs</a> (i.e., <a>cited formulae</a>) as part of regular <a>N3 statements</a>, authors can utilize the N3 Named Graphs extension [<strong>X</strong>] for associating names or identifiers with <a>cited formulae</a>. Although applications could easily introduce their own custom predicates for this purpose, we strongly recommend the use of this extension for interoperability purposes.</p>
-        <p>The N3 Named Graphs extension [<strong>X</strong>] defines a set of <a>builtins</a> (used as predicates) to associate names or identifiers with <a>cited formulae</a>, which then become "named graphs". Moreover, each predicate has a well-defined semantics on how the named graph should be interpreted: as <a>quoted graphs</a> (the default <abbr title="Notation3">N3</abbr> interpretation), a partitioning of triples within a dataset context, sets of triples with their own isolated contexts, or specifying relations between local and online graphs.</p>
+        <p>The N3 Named Graphs extension [<strong>X</strong>] defines a set of <a>built-ins</a> (used as predicates) to associate names or identifiers with <a>cited formulae</a>, which then become "named graphs". Moreover, each predicate has a well-defined semantics on how the named graph should be interpreted: as <a>quoted graphs</a> (the default <abbr title="Notation3">N3</abbr> interpretation), a partitioning of triples within a dataset context, sets of triples with their own isolated contexts, or specifying relations between local and online graphs.</p>
       </section>
     </section>
     <section id='patterns' class=informative>


### PR DESCRIPTION
* Adds algorithm CSS and applies it to the Built-in algorithm.
* Uses section wrappers around sub-sections in built-ins. ReSpec is biased this way, and if some other structuring is desried, we should use different structures.
* Changes more use of "builtin" to "built-in".